### PR TITLE
Use parallelism of 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       name: 'samvera/ruby_fcrepo_solr_redis_postgres'
       ruby_version: << parameters.ruby_version >>
 
-    parallelism: 4
+    parallelism: 1
 
     environment:
       RAILS_VERSION: << parameters.rails_version >>
@@ -96,7 +96,7 @@ jobs:
     parameters:
       parallelism:
         type: integer
-        default: 4
+        default: 1
     docker:
       - image: cimg/base:stable
     steps:


### PR DESCRIPTION
We don't really need 4 parallel builds because we don't have that many tests or that long running of tests.