### PR TITLE
Fix thumbnail url generation

### DIFF
--- a/app/views/hyku/api/v1/collection/_collection.json.jbuilder
+++ b/app/views/hyku/api/v1/collection/_collection.json.jbuilder
@@ -15,7 +15,13 @@ json.rights_statements_for_api_tesim collection.rights_statement&.first
 json.thumbnail_base64_string nil
 json.thumbnail_url collection.thumbnail_path
 if Hyrax::PresenterFactory.build_for(ids: [collection.thumbnail_id], presenter_class: Hyrax::FileSetPresenter, presenter_args: [current_ability, request]).first&.solr_document&.public?
-  json.thumbnail_url URI::Generic.build(scheme: Rails.application.routes.default_url_options.fetch(:protocol, 'http'), host: @account.cname, path: collection.thumbnail_path)
+  components = {
+    scheme: Rails.application.routes.default_url_options.fetch(:protocol, 'http'),
+    host: @account.cname,
+    path: collection.thumbnail_path.split('?')[0],
+    query: collection.thumbnail_path.split('?')[1]
+  }
+  json.thumbnail_url URI::Generic.build(components).to_s
 else
   json.thumbnail_url nil
 end

--- a/app/views/hyku/api/v1/work/_work.json.jbuilder
+++ b/app/views/hyku/api/v1/work/_work.json.jbuilder
@@ -76,7 +76,13 @@ json.source work.source
 json.subject work.subject
 # json.thumbnail_base64_string nil
 if work.representative_presenter&.solr_document&.public?
-  json.thumbnail_url URI::Generic.build(scheme: Rails.application.routes.default_url_options.fetch(:protocol, 'http'), host: @account.cname, path: work.solr_document.thumbnail_path)
+  components = {
+    scheme: Rails.application.routes.default_url_options.fetch(:protocol, 'http'),
+    host: @account.cname,
+    path: work.solr_document.thumbnail_path.split('?')[0],
+    query: work.solr_document.thumbnail_path.split('?')[1]
+  }
+  json.thumbnail_url URI::Generic.build(components).to_s
 else
   json.thumbnail_url nil
 end


### PR DESCRIPTION
This fixes a bug in generating the thumbnail url because `URI::Generic.build` expects that the query is passed independent of the path.