### PR TITLE
REPO-982: Add representative media to works endpoint data. 

### DIFF
--- a/app/presenters/concerns/hyku/api/work_show_presenter_behavior.rb
+++ b/app/presenters/concerns/hyku/api/work_show_presenter_behavior.rb
@@ -4,20 +4,19 @@ module Hyku
   module API
     module WorkShowPresenterBehavior
       extend ActiveSupport::Concern
-      
       # @return FileSetPresenter presenter for the thumbnail FileSets
       def thumbnail_presenter
         return nil if thumbnail_id.blank?
         @thumbnail_presenter ||=
-            begin
-              result = member_presenters_for([thumbnail_id]).first
-              return nil if result.try(:id) == id
-              if result.respond_to?(:thumbnail_presenter)
-                result.thumbnail_presenter
-              else
-                result
-              end
+          begin
+            result = member_presenters_for([thumbnail_id]).first
+            return nil if result.try(:id) == id
+            if result.respond_to?(:thumbnail_presenter)
+              result.thumbnail_presenter
+            else
+              result
             end
+          end
       end
     end
   end

--- a/app/presenters/concerns/hyku/api/work_show_presenter_behavior.rb
+++ b/app/presenters/concerns/hyku/api/work_show_presenter_behavior.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Hyku
+  module API
+    module WorkShowPresenterBehavior
+      extend ActiveSupport::Concern
+      
+      # @return FileSetPresenter presenter for the thumbnail FileSets
+      def thumbnail_presenter
+        return nil if thumbnail_id.blank?
+        @thumbnail_presenter ||=
+            begin
+              result = member_presenters_for([thumbnail_id]).first
+              return nil if result.try(:id) == id
+              if result.respond_to?(:thumbnail_presenter)
+                result.thumbnail_presenter
+              else
+                result
+              end
+            end
+      end
+    end
+  end
+end

--- a/app/views/hyku/api/v1/work/_work.json.jbuilder
+++ b/app/views/hyku/api/v1/work/_work.json.jbuilder
@@ -78,8 +78,13 @@ json.rights_statement work.rights_statement
 #                                         "series_name" => nil,
 json.source work.source
 json.subject work.subject
-# json.thumbnail_base64_string nil
 if work.representative_presenter&.solr_document&.public?
+  json.representative_id work.representative_id
+else
+  json.representative_id nil
+end
+# json.thumbnail_base64_string nil
+if work.thumbnail_presenter&.solr_document&.public?
   components = {
     scheme: Rails.application.routes.default_url_options.fetch(:protocol, 'http'),
     host: @account.cname,

--- a/lib/hyku/api/engine.rb
+++ b/lib/hyku/api/engine.rb
@@ -11,6 +11,16 @@ module Hyku
           mount Hyku::API::Engine, at: '/', as: :hyku_api
         end
       end
+
+      def self.dynamically_include_mixins
+        Hyrax::WorkShowPresenter.include Hyku::API::WorkShowPresenterBehavior
+      end
+
+      if Rails.env.development?
+        config.to_prepare { Hyku::API::Engine.dynamically_include_mixins }
+      else
+        config.after_initialize { Hyku::API::Engine.dynamically_include_mixins }
+      end
     end
   end
 end

--- a/spec/requests/v1/work_spec.rb
+++ b/spec/requests/v1/work_spec.rb
@@ -442,6 +442,7 @@ RSpec.describe Hyku::API::V1::WorkController, type: :request, clean: true, multi
           before do
             work.ordered_members += [file_with_image]
             work.representative_id = file_with_image.id
+            work.thumbnail_id = file_with_image.id
             work.save!
             # FIXME: collection.thumbnail_path is still the default work icon due to the file not getting a derivative generated
           end
@@ -450,6 +451,7 @@ RSpec.describe Hyku::API::V1::WorkController, type: :request, clean: true, multi
             get "/api/v1/tenant/#{account.tenant}/work/#{work.id}"
             expect(response.status).to eq(200)
             expect(json_response).to include("thumbnail_url" => URI.join("http://#{account.cname}", work.to_solr['thumbnail_path_ss']).to_s)
+            expect(json_response).to include("representative_id" => file_with_image.id)
           end
         end
 


### PR DESCRIPTION
Refactors the work JSON thumbnail_url field generation to its own method of WorkShowPresenter.