### PR TITLE
Return JSON 500 when blacklight invalid request raised

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,3 +35,7 @@ Naming/AccessorMethodName:
 Style/BlockDelimiters:
   Exclude:
     - 'app/controllers/hyku/api/v1/reviews_controller.rb'
+
+RSpec/AnyInstance:
+  Exclude:
+    - 'spec/requests/v1/search_spec.rb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,6 +267,8 @@ GEM
     diff-lcs (1.4.4)
     docile (1.3.2)
     docopt (0.5.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     draper (4.0.1)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -361,6 +363,9 @@ GEM
     fcrepo_wrapper (0.9.0)
       ruby-progressbar
     ffi (1.13.1)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     flipflop (2.6.0)
       activesupport (>= 4.0)
     flot-rails (0.0.7)
@@ -399,6 +404,14 @@ GEM
     hiredis (0.6.3)
     honeybadger (3.3.1)
     htmlentities (4.3.4)
+    http (5.0.0)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      llhttp-ffi (~> 0.0.1)
+    http-cookie (1.0.4)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
     http_logger (0.6.0)
     httpclient (2.8.3)
     hydra-access-controls (11.0.6)
@@ -607,6 +620,9 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    llhttp-ffi (0.0.1)
+      ffi-compiler (~> 1.0)
+      rake (~> 13.0)
     lograge (0.11.2)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -902,8 +918,8 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     slop (4.8.2)
-    solr_wrapper (2.2.0)
-      faraday
+    solr_wrapper (3.1.2)
+      http
       retriable
       ruby-progressbar
       rubyzip
@@ -968,6 +984,9 @@ GEM
     uber (0.1.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
     validatable (1.6.7)
     warden (1.2.9)
@@ -1056,7 +1075,7 @@ DEPENDENCIES
   selenium-webdriver
   sidekiq
   simplecov
-  solr_wrapper (~> 2.0)
+  solr_wrapper (>= 3.1.2)
   spring (~> 1.7)
   spring-watcher-listen (~> 2.0.0)
   tether-rails

--- a/app/controllers/concerns/hyku/api/v1/search_behavior.rb
+++ b/app/controllers/concerns/hyku/api/v1/search_behavior.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+module Hyku
+  module API
+    module V1
+      module SearchBehavior
+        extend ActiveSupport::Concern
+
+        include Blacklight::Controller
+        include Hydra::Catalog
+        include Hydra::Controller::ControllerBehavior
+
+        protected
+
+          # Override of Blacklight method to handle exception on redirect
+          # when The index throws an error (Blacklight::Exceptions::InvalidRequest), this method is executed.
+          def handle_request_error(exception)
+            # rubocop:disable Style/GuardClause
+            if Rails.env.development? || Rails.env.test?
+              raise exception # Rails own code will catch and give usual Rails error page with stack trace
+            else
+
+              flash_notice = I18n.t('blacklight.search.errors.request_error')
+
+              # If there are errors coming from the index page, we want to trap those sensibly
+
+              if flash[:notice] == flash_notice
+                logger.error "Cowardly aborting rsolr_request_error exception handling, because we redirected to a page that raises another exception"
+                raise exception
+              end
+
+              logger.error exception
+
+              # Return json instead of redirect to root_path
+              render(json: { status: 500, code: 'Search error', message: flash_notice }, status: 500)
+            end
+            # rubocop:enable Style/GuardClause
+          end
+      end
+    end
+  end
+end

--- a/app/controllers/hyku/api/v1/collection_controller.rb
+++ b/app/controllers/hyku/api/v1/collection_controller.rb
@@ -3,9 +3,7 @@ module Hyku
   module API
     module V1
       class CollectionController < BaseController
-        include Blacklight::Controller
-        include Hydra::Catalog
-        include Hydra::Controller::ControllerBehavior
+        include Hyku::API::V1::SearchBehavior
 
         # self.search_builder Hyrax::CollectionSearchBuilder
         configure_blacklight do |config|

--- a/app/controllers/hyku/api/v1/files_controller.rb
+++ b/app/controllers/hyku/api/v1/files_controller.rb
@@ -3,9 +3,7 @@ module Hyku
   module API
     module V1
       class FilesController < BaseController
-        include Blacklight::Controller
-        include Hydra::Catalog
-        include Hydra::Controller::ControllerBehavior
+        include Hyku::API::V1::SearchBehavior
 
         def index
           @files = authorized_file_set_presenters

--- a/app/controllers/hyku/api/v1/highlights_controller.rb
+++ b/app/controllers/hyku/api/v1/highlights_controller.rb
@@ -3,9 +3,7 @@ module Hyku
   module API
     module V1
       class HighlightsController < BaseController
-        include Blacklight::Controller
-        include Hydra::Catalog
-        include Hydra::Controller::ControllerBehavior
+        include Hyku::API::V1::SearchBehavior
 
         configure_blacklight do |config|
           config.search_builder_class = Hyrax::HomepageSearchBuilder

--- a/app/controllers/hyku/api/v1/search_controller.rb
+++ b/app/controllers/hyku/api/v1/search_controller.rb
@@ -3,9 +3,7 @@ module Hyku
   module API
     module V1
       class SearchController < BaseController
-        include Blacklight::Controller
-        include Hydra::Catalog
-        include Hydra::Controller::ControllerBehavior
+        include Hyku::API::V1::SearchBehavior
 
         include Blacklight::Configurable
         copy_blacklight_config_from(::CatalogController)

--- a/app/controllers/hyku/api/v1/work_controller.rb
+++ b/app/controllers/hyku/api/v1/work_controller.rb
@@ -3,9 +3,7 @@ module Hyku
   module API
     module V1
       class WorkController < BaseController
-        include Blacklight::Controller
-        include Hydra::Catalog
-        include Hydra::Controller::ControllerBehavior
+        include Hyku::API::V1::SearchBehavior
 
         class_attribute :iiif_manifest_builder
         self.iiif_manifest_builder = (Flipflop.cache_work_iiif_manifest? ? Hyrax::CachingIiifManifestBuilder.new : Hyrax::ManifestBuilderService.new)

--- a/spec/requests/v1/search_spec.rb
+++ b/spec/requests/v1/search_spec.rb
@@ -177,6 +177,21 @@ RSpec.describe Hyku::API::V1::SearchController, type: :request, clean: true, mul
         end
       end
     end
+
+    context 'when solr throws an exception' do
+      before do
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
+        allow_any_instance_of(Hyku::API::V1::SearchController).to receive(:search_results).and_raise(Blacklight::Exceptions::InvalidRequest)
+      end
+
+      it 'returns json 500' do
+        get "/api/v1/tenant/#{account.tenant}/search"
+        expect(response.status).to eq(500)
+        expect(json_response['message']).to be_present
+        expect(json_response['code']).to eq 'Search error'
+        expect(json_response['status']).to eq 500
+      end
+    end
   end
 
   describe "/search/facet/:id" do


### PR DESCRIPTION
The easiest way to handle this was overriding the blacklight method
which was redirecting to root_path (which was raising an error itself).
This led me to refactoring the search includes into a behavior mixin
module along with the overridden method.

I only added one test which matched the latest Sentry error for the missing `root_path` method.