### PR TITLE
REPO-1240 Return facets ordered by hits instead of alphabetically.

### DIFF
--- a/app/controllers/hyku/api/v1/search_controller.rb
+++ b/app/controllers/hyku/api/v1/search_controller.rb
@@ -28,10 +28,10 @@ module Hyku
             solr_params = search_builder.with(params).to_h
             solr_params.each_key { |k| solr_params[k] = -1 if k.match?(/^f\..+\.limit$/) }
             @response = repository.search(solr_params)
-            render json: @response.aggregations.transform_values { |v| Hash[v.items.pluck(:value, :hits)] }
+            render json: @response.aggregations.transform_values { |v| hash_of_terms_ordered_by_hits(v.items) }
           else
             super
-            render json: Hash[@display_facet.items[facet_range].pluck(:value, :hits)]
+            render json: hash_of_terms_ordered_by_hits(@display_facet.items[facet_range])
           end
         end
 
@@ -47,6 +47,10 @@ module Hyku
 
           def facet_range
             facet_offset..(facet_offset + facet_limit - 1)
+          end
+
+          def hash_of_terms_ordered_by_hits(items)
+            Hash[items.pluck(:value, :hits).sort_by(&:second).reverse]
           end
       end
     end


### PR DESCRIPTION
Ensures the facets are ordered by the number of hits:

`expect(json_response['keyword_sim'].to_a).to eq({ "test" => 2, "test2" => 1 }.to_a)`